### PR TITLE
Fix dir grab being inconsistent with TIDAL version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "asar": "https://github.com/nekusu/asar/tarball/fix-get-node",
+        "get-file-properties": "^1.0.1",
         "ps-node": "^0.1.6"
       }
     },
@@ -98,6 +99,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/get-file-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-file-properties/-/get-file-properties-1.0.1.tgz",
+      "integrity": "sha512-46xG/mXgpE1T0sCh/dg10t1DKecxyLyUUyy0UwYsFIoEX5yKFSIdnyY5FGC9uyF3pT7BgJ4hyurbmdxyXXd5cw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -253,6 +260,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "get-file-properties": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-file-properties/-/get-file-properties-1.0.1.tgz",
+      "integrity": "sha512-46xG/mXgpE1T0sCh/dg10t1DKecxyLyUUyy0UwYsFIoEX5yKFSIdnyY5FGC9uyF3pT7BgJ4hyurbmdxyXXd5cw=="
     },
     "glob": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "private": true,
   "dependencies": {
     "asar": "https://github.com/nekusu/asar/tarball/fix-get-node",
+    "get-file-properties": "^1.0.1",
     "ps-node": "^0.1.6"
   }
 }


### PR DESCRIPTION
When TIDAL updates and bumps its patch version, the app directory changes. Changes fix app directory grab by retrieved the TIDAL version via WMI.  